### PR TITLE
Allow expanding rows in occlusion mode 

### DIFF
--- a/addon/templates/components/lt-body.hbs
+++ b/addon/templates/components/lt-body.hbs
@@ -97,6 +97,12 @@
                      canSelect=canSelect
                      click=(action 'onRowClick' row)
                      doubleClick=(action 'onRowDoubleClick' row)}}
+                     
+           {{yield (hash
+                      expanded-row=(component lt.spanned-row classes='lt-expanded-row' colspan=colspan yield=row visible=row.expanded)
+                      loader=(component lt.spanned-row visible=false)
+                      no-data=(component lt.spanned-row visible=false)
+                    ) rows}}
           {{/vertical-collection}}
           {{yield (hash
                     loader=(component lt.spanned-row classes='lt-is-loading')


### PR DESCRIPTION
pretty straightforward, I can't find a reason that this won't work. But ultimately if someone is experiencing problems they can just turn expanded rows off or occlusion off

see https://github.com/offirgolan/ember-light-table/issues/542