### PR TITLE
WIP: Table Sorting icons

### DIFF
--- a/addon/templates/components/columns/base.hbs
+++ b/addon/templates/components/columns/base.hbs
@@ -15,7 +15,12 @@
       sortIconProperty=this.sortIconProperty
     }}
   {{else if this.sortIconProperty}}
-    <i class='lt-sort-icon {{get this.sortIcons this.sortIconProperty}}'></i>
+    <i class="lt-sort-icon">
+      <FaIcon
+        @prefix="fas"
+        @icon={{get this.sortIcons this.sortIconProperty}}
+      />
+    </i>
   {{/if}}
   {{this.label}}
 {{/if}}

--- a/config/icons.js
+++ b/config/icons.js
@@ -1,10 +1,10 @@
 module.exports = function () {
   return {
     'free-brands-svg-icons': ['facebook', 'github', 'twitter'],
+    'free-regular-svg-icons': ['check-square', 'square', 'trash-alt'],
     'free-solid-svg-icons': [
       'bell',
       'caret-down',
-      'check-square',
       'chevron-down',
       'chevron-left',
       'chevron-right',
@@ -13,8 +13,6 @@ module.exports = function () {
       'sort',
       'sort-down',
       'sort-up',
-      'square',
-      'trash',
     ],
   };
 };

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@fortawesome/ember-fontawesome": "^0.2.2",
     "@fortawesome/free-brands-svg-icons": "^5.15.2",
+    "@fortawesome/free-regular-svg-icons": "^5.15.2",
     "@fortawesome/free-solid-svg-icons": "^5.15.2",
     "@html-next/vertical-collection": "^3.0.0",
     "ember-cli-babel": "^7.26.6",

--- a/tests/dummy/app/components/rows/selectable-table.js
+++ b/tests/dummy/app/components/rows/selectable-table.js
@@ -1,11 +1,13 @@
 // BEGIN-SNIPPET selectable-table
 import BaseTable from '../base-table';
-import { computed, action } from '@ember/object';
+import { action } from '@ember/object';
 import classic from 'ember-classic-decorator';
 
 @classic
 export default class ExpandableTable extends BaseTable {
-  hasSelection = computed.notEmpty('table.selectedRows');
+  get hasSelection() {
+    return this.table.selectedRows;
+  }
 
   get columns() {
     return [

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -77,7 +77,7 @@
         </li>
 
         <li><a href="docs">Documentation</a></li>
-        <li><a href="https://github.com/adopted-ember-addons/ember-light-table" class="fa fa-github github"></a></li>
+        <li><a href="https://github.com/adopted-ember-addons/ember-light-table" ><FaIcon @prefix="fab" @icon="github" /></a></li>
       </ul>
     </div>
   </div>
@@ -86,5 +86,5 @@
 {{outlet}}
 
 <div class="tip">
-  <i class="fa fa-info-circle icon-info"></i> Click on the panel header with the <i class="fa fa-code"></i> icon to see code snippets associated with this table.
+  <i class="fa fa-info-circle icon-info"></i> Click on the panel header with the <FaIcon @prefix="fas" @icon="code" /> icon to see code snippets associated with this table.
 </div>

--- a/tests/dummy/app/templates/components/code-panel.hbs
+++ b/tests/dummy/app/templates/components/code-panel.hbs
@@ -2,7 +2,7 @@
   <div class="panel panel-default">
     <div class="panel-heading">
       <a role="button" data-toggle="collapse" data-parent="#{{concat this.elementId "-code-panel"}}" href="#{{concat this.elementId "-code-snippet"}}">
-        <h4 class="panel-title">{{@title}} <span class="code-icon fa fa-code pull-right"></span></h4>
+        <h4 class="panel-title">{{@title}} <span class="code-icon pull-right"><FaIcon @prefix="fas" @icon="code" /></span></h4>
       </a>
     </div>
 

--- a/tests/dummy/app/templates/components/columns/draggable-table.hbs
+++ b/tests/dummy/app/templates/components/columns/draggable-table.hbs
@@ -2,9 +2,9 @@
 <LightTable @table={{this.table}} @height="65vh" as |t|>
   <t.head
     @onColumnClick={{this.onColumnClick}}
-    @iconSortable="fa fa-sort"
-    @iconAscending="fa fa-sort-up"
-    @iconDescending="fa fa-sort-down"
+    @iconSortable="sort"
+    @iconAscending="sort-up"
+    @iconDescending="sort-down"
     @fixed={{true}}
   />
 

--- a/tests/dummy/app/templates/components/columns/grouped-table.hbs
+++ b/tests/dummy/app/templates/components/columns/grouped-table.hbs
@@ -2,9 +2,9 @@
 <LightTable @table={{this.table}} @height="65vh" as |t|>
   <t.head
     @onColumnClick={{this.onColumnClick}}
-    @iconSortable="fa fa-sort"
-    @iconAscending="fa fa-sort-up"
-    @iconDescending="fa fa-sort-down"
+    @iconSortable="sort"
+    @iconAscending="sort-up"
+    @iconDescending="sort-down"
     @fixed={{true}}
   />
 

--- a/tests/dummy/app/templates/components/columns/resizable-table.hbs
+++ b/tests/dummy/app/templates/components/columns/resizable-table.hbs
@@ -3,9 +3,9 @@
 
   <t.head
     @onColumnClick={{this.onColumnClick}}
-    @iconSortable="fa fa-sort"
-    @iconAscending="fa fa-sort-up"
-    @iconDescending="fa fa-sort-down"
+    @iconSortable="sort"
+    @iconAscending="sort-up"
+    @iconDescending="sort-down"
     @resizeOnDrag={{true}}
     @fixed={{true}}
   />

--- a/tests/dummy/app/templates/components/cookbook/client-side-table.hbs
+++ b/tests/dummy/app/templates/components/cookbook/client-side-table.hbs
@@ -9,9 +9,9 @@
 
   <t.head
     @onColumnClick={{this.onColumnClick}}
-    @iconSortable="fa fa-sort"
-    @iconAscending="fa fa-sort-up"
-    @iconDescending="fa fa-sort-down"
+    @iconSortable="sort"
+    @iconAscending="sort-up"
+    @iconDescending="sort-down"
     @fixed={{true}}
   />
 

--- a/tests/dummy/app/templates/components/cookbook/custom-row-table.hbs
+++ b/tests/dummy/app/templates/components/cookbook/custom-row-table.hbs
@@ -9,9 +9,9 @@
 
   <t.head
     @onColumnClick={{this.onColumnClick}}
-    @iconSortable="fa fa-sort"
-    @iconAscending="fa fa-sort-up"
-    @iconDescending="fa fa-sort-down"
+    @iconSortable="sort"
+    @iconAscending="sort-up"
+    @iconDescending="sort-down"
     @fixed={{true}}
   />
 

--- a/tests/dummy/app/templates/components/cookbook/horizontal-scrolling-table.hbs
+++ b/tests/dummy/app/templates/components/cookbook/horizontal-scrolling-table.hbs
@@ -9,9 +9,9 @@
 
   <t.head
     @onColumnClick={{this.onColumnClick}}
-    @iconSortable="fa fa-sort"
-    @iconAscending="fa fa-sort-up"
-    @iconDescending="fa fa-sort-down"
+    @iconSortable="sort"
+    @iconAscending="sort-up"
+    @iconDescending="sort-down"
     @fixed={{true}}
   />
 

--- a/tests/dummy/app/templates/components/cookbook/paginated-table.hbs
+++ b/tests/dummy/app/templates/components/cookbook/paginated-table.hbs
@@ -9,9 +9,9 @@
 
   <t.head
     @onColumnClick={{pipe this.onColumnClick (fn this.setPage 1)}}
-    @iconSortable="fa fa-sort"
-    @iconAscending="fa fa-sort-up"
-    @iconDescending="fa fa-sort-down"
+    @iconSortable="sort"
+    @iconAscending="sort-up"
+    @iconDescending="sort-down"
     @fixed={{true}}
   />
 

--- a/tests/dummy/app/templates/components/cookbook/table-actions-table.hbs
+++ b/tests/dummy/app/templates/components/cookbook/table-actions-table.hbs
@@ -16,9 +16,9 @@ as |t|>
 
   <t.head
     @onColumnClick={{this.onColumnClick}}
-    @iconSortable="fa fa-sort"
-    @iconAscending="fa fa-sort-up"
-    @iconDescending="fa fa-sort-down"
+    @iconSortable="sort"
+    @iconAscending="sort-up"
+    @iconDescending="sort-down"
     @fixed={{true}}
   />
 

--- a/tests/dummy/app/templates/components/expanded-row.hbs
+++ b/tests/dummy/app/templates/components/expanded-row.hbs
@@ -7,9 +7,9 @@
     <p>{{@row.bio}}</p>
 
     <div class="user-actions">
-      <a class="fa fa-envelope" href="mailto:{{@row.email}}"></a>
-      <a class="fa fa-facebook" href="#"></a>
-      <a class="fa fa-twitter" href="#"></a>
+      <a class="" href="mailto:{{@row.email}}"><FaIcon @prefix="fas" @icon="envelope" /></a>
+      <a class="" href="#"><FaIcon @prefix="fab" @icon="facebook" /></a>
+      <a class="" href="#"><FaIcon @prefix="fab" @icon="twitter" /></a>
     </div>
   </div>
 </div>

--- a/tests/dummy/app/templates/components/responsive-table.hbs
+++ b/tests/dummy/app/templates/components/responsive-table.hbs
@@ -14,9 +14,9 @@ as |t|>
 
   <t.head
     @onColumnClick={{this.onColumnClick}}
-    @iconSortable="fa fa-sort"
-    @iconAscending="fa fa-sort-up"
-    @iconDescending="fa fa-sort-down"
+    @iconSortable="sort"
+    @iconAscending="sort-up"
+    @iconDescending="sort-down"
     @fixed={{true}}
   />
 

--- a/tests/dummy/app/templates/components/responsive-table.hbs
+++ b/tests/dummy/app/templates/components/responsive-table.hbs
@@ -39,9 +39,9 @@ as |t|>
   <t.foot @fixed={{true}} as |columns|>
     <tr>
       <td class="align-center" colspan={{columns.length}}>
-        <i class="fa fa-chevron-left pull-left" aria-hidden="true"></i>
+        <i class="pull-left" aria-hidden="true"><FaIcon @prefix="fas" @icon="chevron-left" /></i>
         Resize your browser to check out the responsive behavior
-        <i class="fa fa-chevron-right pull-right" aria-hidden="true"></i>
+        <i class="pull-right" aria-hidden="true"><FaIcon @prefix="fas" @icon="chevron-right" /></i>
       </td>
     </tr>
   </t.foot>

--- a/tests/dummy/app/templates/components/row-toggle.hbs
+++ b/tests/dummy/app/templates/components/row-toggle.hbs
@@ -1,8 +1,14 @@
-{{!-- BEGIN-SNIPPET row-toggle --}}
-<button class="row-toggle"
+{{! BEGIN-SNIPPET row-toggle }}
+<button
+  class="row-toggle"
   type="button"
   {{on "click" (fn (toggle "expanded" @row))}}
 >
-  <i class="fa {{if @row.expanded "fa-chevron-down" "fa-chevron-right"}}"></i>
+  <i>{{if
+      @row.is-expanded
+      (component "fa-icon" prefix="fas" icon="chevron-down")
+      (component "fa-icon" prefix="fas" icon="chevron-up")
+    }}
+  </i>
 </button>
-{{!-- END-SNIPPET --}}
+{{! END-SNIPPET }}

--- a/tests/dummy/app/templates/components/rows/expandable-table.hbs
+++ b/tests/dummy/app/templates/components/rows/expandable-table.hbs
@@ -2,9 +2,9 @@
 <LightTable @table={{this.table}} @height="65vh" as |t|>
   <t.head
     @onColumnClick={{this.onColumnClick}}
-    @iconSortable="fa fa-sort"
-    @iconAscending="fa fa-sort-up"
-    @iconDescending="fa fa-sort-down"
+    @iconSortable="sort"
+    @iconAscending="sort-up"
+    @iconDescending="sort-down"
     @fixed={{true}}
   />
 

--- a/tests/dummy/app/templates/components/rows/selectable-table.hbs
+++ b/tests/dummy/app/templates/components/rows/selectable-table.hbs
@@ -32,9 +32,9 @@
 <LightTable @table={{this.table}} @height="65vh" as |t|>
   <t.head
     @onColumnClick={{this.onColumnClick}}
-    @iconSortable="fa fa-sort"
-    @iconAscending="fa fa-sort-up"
-    @iconDescending="fa fa-sort-down"
+    @iconSortable="sort"
+    @iconAscending="sort-up"
+    @iconDescending="sort-down"
     @fixed={{true}}
   />
 

--- a/tests/dummy/app/templates/components/rows/selectable-table.hbs
+++ b/tests/dummy/app/templates/components/rows/selectable-table.hbs
@@ -2,24 +2,30 @@
 <div class="table-actions">
   {{#if this.hasSelection}}
     <div
-      class="table-action fa fa-check-square"
+      class="table-action"
       title="Deselect all"
       role="button"
       {{on "click" this.deselectAll}}
-    ></div>
+    >
+      <FaIcon @prefix="far" @icon="check-square" />
+    </div>
     <div
-      class="table-action fa fa-trash delete"
+      class="table-action"
       title="Delete selected"
       role="button"
       {{on "click" this.deleteAll}}
-    ></div>
+    >
+      <FaIcon @prefix="far" @icon="trash-alt" />
+    </div>
   {{else}}
     <div
-      class="table-action fa fa-square"
+      class="table-action"
       title="Select all"
       role="button"
       {{on "click" this.selectAll}}
-    ></div>
+    >
+      <FaIcon @prefix="far" @icon="square" />
+    </div>
   {{/if}}
 </div>
 
@@ -34,7 +40,8 @@
 
   <t.body
     @multiSelect={{true}}
-    @onScrolledToBottom={{this.onScrolledToBottom}} as |body|
+    @onScrolledToBottom={{this.onScrolledToBottom}}
+    as |body|
   >
     {{#if this.isLoading}}
       <body.loader>

--- a/tests/dummy/app/templates/components/scrolling-table.hbs
+++ b/tests/dummy/app/templates/components/scrolling-table.hbs
@@ -9,9 +9,9 @@
 
   <t.head
     @onColumnClick={{this.onColumnClick}}
-    @iconSortable="fa fa-sort"
-    @iconAscending="fa fa-sort-up"
-    @iconDescending="fa fa-sort-down"
+    @iconSortable="sort"
+    @iconAscending="sort-up"
+    @iconDescending="sort-down"
     @fixed={{true}}
   />
 

--- a/tests/dummy/app/templates/components/simple-table.hbs
+++ b/tests/dummy/app/templates/components/simple-table.hbs
@@ -9,9 +9,9 @@
 
   <t.head
     @onColumnClick={{this.onColumnClick}}
-    @iconSortable="fa fa-sort"
-    @iconAscending="fa fa-sort-up"
-    @iconDescending="fa fa-sort-down"
+    @iconSortable="sort"
+    @iconAscending="sort-up"
+    @iconDescending="sort-down"
     @fixed={{true}}
   />
 

--- a/tests/dummy/app/templates/components/user-actions.hbs
+++ b/tests/dummy/app/templates/components/user-actions.hbs
@@ -1,12 +1,16 @@
-{{!-- BEGIN-SNIPPET user-actions --}}
+{{! BEGIN-SNIPPET user-actions }}
 <button
-    type="button"
-    class="btn btn-sm btn-default fa fa-bell"
-    {{on "click" (fn @tableActions.notifyUser @row bubbles=false)}}
-></button>
+  type="button"
+  class="btn btn-sm btn-default"
+  {{on "click" (fn @tableActions.notifyUser @row bubbles=false)}}
+>
+  <FaIcon @prefix="fas" @icon="bell" />
+</button>
 <button
-    type="button"
-    class="btn btn-sm btn-danger fa fa-trash"
-    {{on "click" (fn @tableActions.deleteUser @row bubbles=false)}}
-></button>
-{{!-- END-SNIPPET --}}
+  type="button"
+  class="btn btn-sm btn-danger"
+  {{on "click" (fn @tableActions.deleteUser @row bubbles=false)}}
+>
+  <FaIcon @prefix="far" @icon="trash-alt" />
+</button>
+{{! END-SNIPPET }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1343,6 +1343,13 @@
   dependencies:
     "@fortawesome/fontawesome-common-types" "^0.2.36"
 
+"@fortawesome/free-regular-svg-icons@^5.15.2":
+  version "5.15.4"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.15.4.tgz#b97edab436954333bbeac09cfc40c6a951081a02"
+  integrity sha512-9VNNnU3CXHy9XednJ3wzQp6SwNwT3XaM26oS4Rp391GsxVYA+0oDR2J194YCIWf7jNRCYKjUCOduxdceLrx+xw==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.36"
+
 "@fortawesome/free-solid-svg-icons@^5.15.2":
   version "5.15.4"
   resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.4.tgz#2a68f3fc3ddda12e52645654142b9e4e8fbb6cc5"


### PR DESCRIPTION
Uses ember-fontawesome `FaIcon` component for sorting icons.

A thoughts/questions:

* Addon could be updated to use the sorting icons without requiring `@iconSortable`,  ` @iconAscending`, `@iconDescending` in every table template.  Less boilerplate and only needed if you have a custom `@iconComponent`. Too much hidden or magic?

* How to document readme, demo comments, yuidocs, all?