### PR TITLE
Make light-table tagless

### DIFF
--- a/addon/components/light-table.hbs
+++ b/addon/components/light-table.hbs
@@ -1,31 +1,38 @@
-{{yield
-  (hash
-    head=(component
-      'lt-head'
-      tableId=this.elementId
-      table=this.table
-      tableActions=this.tableActions
-      extra=this.extra
-      tableClassNames=this.tableClassNames
-      sharedOptions=this.sharedOptions
+<div
+  class="ember-light-table {{if this.occlusion "occlusion"}}"
+  id={{or this.attrs.id this.tableId}}
+  style={{this.style}}
+  ...attributes
+>
+  {{yield
+    (hash
+      head=(component
+        "lt-head"
+        tableId=(or this.attrs.id this.tableId)
+        table=this.table
+        tableActions=this.tableActions
+        extra=this.extra
+        tableClassNames=this.tableClassNames
+        sharedOptions=this.sharedOptions
+      )
+      body=(component
+        "lt-body"
+        tableId=(or this.attrs.id this.tableId)
+        table=this.table
+        tableActions=this.tableActions
+        extra=this.extra
+        tableClassNames=this.tableClassNames
+        sharedOptions=this.sharedOptions
+      )
+      foot=(component
+        "lt-foot"
+        tableId=(or this.attrs.id this.tableId)
+        table=this.table
+        tableActions=this.tableActions
+        extra=this.extra
+        tableClassNames=this.tableClassNames
+        sharedOptions=this.sharedOptions
+      )
     )
-    body=(component
-      'lt-body'
-      tableId=this.elementId
-      table=this.table
-      tableActions=this.tableActions
-      extra=this.extra
-      tableClassNames=this.tableClassNames
-      sharedOptions=this.sharedOptions
-    )
-    foot=(component
-      'lt-foot'
-      tableId=this.elementId
-      table=this.table
-      tableActions=this.tableActions
-      extra=this.extra
-      tableClassNames=this.tableClassNames
-      sharedOptions=this.sharedOptions
-    )
-  )
-}}
+  }}
+</div>

--- a/addon/components/light-table.js
+++ b/addon/components/light-table.js
@@ -2,6 +2,7 @@ import { A as emberArray } from '@ember/array';
 import Component from '@ember/component';
 import { computed, observer } from '@ember/object';
 import { readOnly } from '@ember/object/computed';
+import { guidFor } from '@ember/object/internals';
 import { isEmpty, isNone } from '@ember/utils';
 import { assert } from '@ember/debug';
 import { inject as service } from '@ember/service';
@@ -36,8 +37,7 @@ function intersections(array1, array2) {
  */
 
 const LightTable = Component.extend({
-  classNameBindings: [':ember-light-table', 'occlusion'],
-  attributeBindings: ['style'],
+  tagName: '',
 
   media: service(),
   scrollbarThickness: service(),
@@ -293,6 +293,8 @@ const LightTable = Component.extend({
       '[ember-light-table] table must be an instance of Table',
       table instanceof Table
     );
+
+    this.set('tableId', guidFor(this));
 
     if (isNone(this.media)) {
       this.set('responsive', false);


### PR DESCRIPTION
Could be breaking, simply because of not being able to pass a different `tagName` in etc