### PR TITLE
Bump vertical-collection to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.15.2",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
-    "@html-next/vertical-collection": "^3.1.0",
+    "@html-next/vertical-collection": "^4.0.2",
     "ember-classic-decorator": "^3.0.0",
     "ember-cli-babel": "^7.26.6",
     "ember-cli-htmlbars": "^5.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1506,19 +1506,18 @@
   resolved "https://registry.yarnpkg.com/@handlebars/parser/-/parser-1.1.0.tgz#d6dbc7574774b238114582410e8fee0dc3532bdf"
   integrity sha512-rR7tJoSwJ2eooOpYGxGGW95sLq6GXUaS1UtWvN7pei6n2/okYvCGld9vsUTvkl2migxbkszsycwtMf/GEc1k1A==
 
-"@html-next/vertical-collection@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@html-next/vertical-collection/-/vertical-collection-3.1.0.tgz#3e271fe36bbf381b5e6f7702fde72f8c6880ae0d"
-  integrity sha512-7mzdEhPA0SzIAqZA/HUwmAYVxzbsKp4l8vB7oBc6A71IGusrNZQUMLl09Vi9wgHahvhBV89LST474cu9k2Iw1Q==
+"@html-next/vertical-collection@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@html-next/vertical-collection/-/vertical-collection-4.0.2.tgz#7e9885423eb8c445bce0cc110ac3be281ca6ff87"
+  integrity sha512-S8cgntEDdXrOwdylVGDh1BFe+nX5uuUzzb3teh1FE++/kbqsOfUpXOYRUsEzsqb0fRqcm6eLxvtNb282Zr67rQ==
   dependencies:
     babel6-plugin-strip-class-callcheck "^6.0.0"
-    broccoli-funnel "^2.0.2"
-    broccoli-merge-trees "^3.0.1"
-    broccoli-rollup "^4.1.1"
+    broccoli-funnel "^3.0.8"
+    broccoli-merge-trees "^4.2.0"
+    broccoli-rollup "^5.0.0"
     ember-cli-babel "^7.12.0"
-    ember-cli-htmlbars "^5.0.0"
-    ember-cli-version-checker "^3.1.3"
-    ember-compatibility-helpers "^1.2.1"
+    ember-cli-htmlbars "^6.0.0"
+    ember-cli-version-checker "^5.1.2"
     ember-raf-scheduler "^0.3.0"
 
 "@humanwhocodes/config-array@^0.5.0":
@@ -5271,7 +5270,7 @@ ember-cli-htmlbars@^4.3.1:
     strip-bom "^4.0.0"
     walk-sync "^2.0.2"
 
-ember-cli-htmlbars@^5.0.0, ember-cli-htmlbars@^5.2.0, ember-cli-htmlbars@^5.3.1, ember-cli-htmlbars@^5.7.1:
+ember-cli-htmlbars@^5.2.0, ember-cli-htmlbars@^5.3.1, ember-cli-htmlbars@^5.7.1:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz#e0cd2fb3c20d85fe4c3e228e6f0590ee1c645ba8"
   integrity sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==


### PR DESCRIPTION
Currently version 3.1.0 of `@html-next/vertical-collection` is used. This has the following known issue: https://github.com/html-next/vertical-collection/issues/397. This is fixed in the v4 release.

According to the [changelog](https://github.com/html-next/vertical-collection/blob/master/CHANGELOG.md) this shouldn't introduce breaking changes for this addon as far as I can tell.