### PR TITLE
Fix: Remove ember-classic-decorator package and usage

### DIFF
--- a/addon/classes/Column.js
+++ b/addon/classes/Column.js
@@ -3,13 +3,11 @@ import EmberObject, { computed } from '@ember/object';
 import { notEmpty, or } from '@ember/object/computed';
 import { isEmpty } from '@ember/utils';
 import { guidFor } from '@ember/object/internals';
-import classic from 'ember-classic-decorator';
 
 /**
  * @module Table
  * @class Column
  */
-@classic
 export default class Column extends EmberObject.extend({
   /**
    * Whether the column can be hidden.

--- a/addon/classes/Row.js
+++ b/addon/classes/Row.js
@@ -1,14 +1,12 @@
 import ObjectProxy from '@ember/object/proxy';
 import { computed } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
-import classic from 'ember-classic-decorator';
 
 /**
  * @module Table
  * @extends Ember.ObjectProxy
  * @class Row
  */
-@classic
 export default class Row extends ObjectProxy.extend({
   /**
    * Whether the row is hidden.

--- a/addon/classes/Table.js
+++ b/addon/classes/Table.js
@@ -6,7 +6,6 @@ import Row from 'ember-light-table/classes/Row';
 import Column from 'ember-light-table/classes/Column';
 import { mergeOptionsWithGlobals } from 'ember-light-table/-private/global-options';
 import { isNone } from '@ember/utils';
-import classic from 'ember-classic-decorator';
 
 /**
  * @module Table
@@ -17,7 +16,6 @@ import classic from 'ember-classic-decorator';
  * @module Table
  * @class Table
  */
-@classic
 export default class Table extends EmberObject.extend({
   /**
    * @property columns

--- a/addon/components/lt-head.js
+++ b/addon/components/lt-head.js
@@ -1,6 +1,5 @@
 import Component from '@ember/component';
 import TableHeaderMixin from 'ember-light-table/mixins/table-header';
-import classic from 'ember-classic-decorator';
 
 /**
  * @module Light Table
@@ -32,7 +31,6 @@ import classic from 'ember-classic-decorator';
  * @uses TableHeaderMixin
  */
 
-@classic
 export default class LtHeadComponent extends Component.extend(
   TableHeaderMixin
 ) {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
     "@html-next/vertical-collection": "^4.0.2",
-    "ember-classic-decorator": "^3.0.1",
     "ember-cli-babel": "^7.26.11",
     "ember-cli-htmlbars": "^6.1.1",
     "ember-get-config": "^2.1.1",

--- a/tests/dummy/app/components/colored-row.js
+++ b/tests/dummy/app/components/colored-row.js
@@ -1,10 +1,8 @@
 // BEGIN-SNIPPET colored-row
-import classic from 'ember-classic-decorator';
 import { classNames, attributeBindings } from '@ember-decorators/component';
 import { htmlSafe } from '@ember/template';
 import Row from 'ember-light-table/components/lt-row';
 
-@classic
 @classNames('colored-row')
 @attributeBindings('style')
 export default class ColoredRow extends Row {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5118,16 +5118,6 @@ ember-classic-decorator@^3.0.0:
     ember-cli-babel "^7.26.11"
     ember-cli-htmlbars "^6.0.1"
 
-ember-classic-decorator@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/ember-classic-decorator/-/ember-classic-decorator-3.0.1.tgz#13acf53e5fdb1f867919765853eb3592380ed1ef"
-  integrity sha512-IoocHPX1cY93Sma7VeDGbF0M1+TkBWDJLus+RD01902eD+KHEL2+diwM+iayCyO+1/xaUzdzNGh35J+i+TCxoA==
-  dependencies:
-    "@embroider/macros" "^1.0.0"
-    babel-plugin-filter-imports "^4.0.0"
-    ember-cli-babel "^7.26.11"
-    ember-cli-htmlbars "^6.0.1"
-
 ember-cli-babel-plugin-helpers@^1.0.0, ember-cli-babel-plugin-helpers@^1.1.0, ember-cli-babel-plugin-helpers@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.1.tgz#5016b80cdef37036c4282eef2d863e1d73576879"


### PR DESCRIPTION
The `ember-classic-decorator` package is not compatible with Ember 5.x.
Remove it from the `ember-light-table` to make it work on Ember 5 projects.